### PR TITLE
adding support to save session info across addon restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a simple dig tracker for FFXI. This addon works with Ashita v4.
 
 /hgather report - Prints the dig data to chatlog
 
-/hgather reset - Resets the digging data
+/hgather clear - Clears the digging session data
 
 ## Pricing
 Pricing for items is listed under the configuration window under the Items tab. Make sure the format is as follows:


### PR DESCRIPTION
Session stats can be saved across addon reloads (log-off / log-on).  This supports folks that need to gather across multiple parts of the day.

Began the effort to restructure the data structure to make handling multiple HELM/digging activities easier.

Added some more error handling around format_int() function to handle weird edge cases.